### PR TITLE
Recycle existing binaries, startup script not in use

### DIFF
--- a/binaries/checksums.json
+++ b/binaries/checksums.json
@@ -1,8 +1,8 @@
 {
-  ".gitignore_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  ".gitignore_size": "0",
-  "openwrt-ath79-nand-glinet_gl-ar300m-nor-squashfs-sysupgrade.bin_checksum": "d01a910992352b47715e31efc4b1c15517b9b2bb4afca7cd06904b1b17ba3a26",
-  "openwrt-ath79-nand-glinet_gl-ar300m-nor-squashfs-sysupgrade.bin_size": "14615374",
+  "openwrt-ath79-nand-glinet_gl-ar300m-nor-squashfs-sysupgrade_b2dd74068d02951c979678444e6a43be011a8ef2.bin_checksum": "c7ba6a56fa5d48d424d784ab9b4ab25a3081b77b4dfde8fe963e043ff66b10e2",
+  "openwrt-ath79-nand-glinet_gl-ar300m-nor-squashfs-sysupgrade_b2dd74068d02951c979678444e6a43be011a8ef2.bin_size": "14615374",
   "upload_new_files.sh_checksum": "4197b8f2ab8f92251914cbbe4f59e7b666072d20087c20e1e163a19b2f755297",
-  "upload_new_files.sh_size": "501"
+  "upload_new_files.sh_size": "501",
+  ".gitignore_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  ".gitignore_size": "0"
 }

--- a/build_custom_dependencies.sh
+++ b/build_custom_dependencies.sh
@@ -7,6 +7,23 @@ SCRIPT_DIR="$HOME/TollGateNostrToolKit"
 OPENWRT_DIR="$HOME/openwrt"
 ROUTERS_DIR="$SCRIPT_DIR/routers"
 
+# Define a function to map router types to target and subtarget
+get_target_subtarget() {
+    local router_type=$1
+    case $router_type in
+        "ath79_gl-ar300m-nor")
+            echo "ath79 nand"
+            ;;
+        "ramips_mt7621")
+            echo "ramips mt7621"
+            ;;
+        # Add more mappings here as needed
+        *)
+            echo "unknown unknown"
+            ;;
+    esac
+}
+
 # Debug: Print current paths and variables
 echo "SCRIPT_DIR: $SCRIPT_DIR"
 echo "OPENWRT_DIR: $OPENWRT_DIR"
@@ -27,12 +44,50 @@ get_latest_commit() {
     git -C "$1" rev-parse HEAD
 }
 
-# Function to extract custom feed URL and branch from feeds.conf
+# Function to check if router configs have changed
+check_router_changes() {
+    echo "Checking for router config changes..."
+    if [ ! -f "$OPENWRT_DIR/.last_build_commit" ]; then
+        echo "Change detected: No previous build commit file found."
+        return 0
+    fi
+    local last_commit=$(cat "$OPENWRT_DIR/.last_build_commit")
+    echo "Last build commit: $last_commit"
+    echo "Current commit: $(git -C "$SCRIPT_DIR" rev-parse HEAD)"
+    echo "Checking for changes in routers/ directory since last build..."
+    if git -C "$SCRIPT_DIR" diff --quiet "$last_commit" HEAD -- routers/; then
+        echo "No changes detected in routers/ directory."
+        return 1
+    else
+        echo "Changes detected in routers/ directory."
+        git -C "$SCRIPT_DIR" diff --name-only "$last_commit" HEAD -- routers/
+        return 0
+    fi
+}
+
+# Function to check if custom feeds have changed
+check_custom_feed_changes() {
+    echo "Checking for custom feed changes..."
+    if [ ! -f "$OPENWRT_DIR/.last_build_info" ]; then
+        echo "Change detected: No previous build info file found."
+        return 0
+    fi
+    local last_custom_feed_commit=$(grep CUSTOM_FEED_COMMIT "$OPENWRT_DIR/.last_build_info" | cut -d= -f2)
+    echo "Last custom feed commit: $last_custom_feed_commit"
+    echo "Current custom feed commit: $CUSTOM_FEED_COMMIT"
+    if [ "$CUSTOM_FEED_COMMIT" != "$last_custom_feed_commit" ]; then
+        echo "Custom feed commit has changed."
+        return 0
+    else
+        echo "No changes in custom feed commit."
+        return 1
+    fi
+}
+
+# Function to extract custom feed info from feeds.conf
 get_custom_feed_info() {
-    local feed_line=$(grep "src-git-full custom" "$1")
-    local url=$(echo "$feed_line" | cut -d' ' -f3 | cut -d';' -f1)
-    local branch=$(echo "$feed_line" | cut -d';' -f2)
-    echo "$url $branch"
+    local feeds_conf="$1"
+    grep "^src-git-full custom" "$feeds_conf" | awk '{print $3}' | sed 's/;/ /'
 }
 
 # Get custom feed URL and branch
@@ -60,10 +115,18 @@ CUSTOM_FEED_COMMIT=$(get_latest_commit "$CUSTOM_FEED_DIR")
 
 # Check if rebuild is necessary
 REBUILD_NEEDED=false
-if [ ! -f .last_build_info ] || \
-   [ "$SCRIPT_COMMIT" != "$(grep SCRIPT_COMMIT .last_build_info | cut -d= -f2)" ] || \
-   [ "$CUSTOM_FEED_COMMIT" != "$(grep CUSTOM_FEED_COMMIT .last_build_info | cut -d= -f2)" ]; then
+if check_router_changes || check_custom_feed_changes; then
     REBUILD_NEEDED=true
+    echo "Changes detected. Rebuild needed."
+else
+    REBUILD_NEEDED=false
+    echo "No changes detected. Using existing build."
+fi
+
+# Check if only configuration has changed
+CONFIG_CHANGED=false
+if [ "$SCRIPT_COMMIT" != "$(grep SCRIPT_COMMIT .last_build_info | cut -d= -f2)" ]; then
+    CONFIG_CHANGED=true
 fi
 
 cp $SCRIPT_DIR/feeds.conf $OPENWRT_DIR/feeds.conf
@@ -104,16 +167,52 @@ fi
 # Run install_script.sh
 $SCRIPT_DIR/install_script.sh "$SCRIPT_DIR" "$OPENWRT_DIR"
 
-# Build firmware if needed
+echo "Checking if rebuild is needed..."
+if check_router_changes; then
+    REBUILD_NEEDED=true
+    echo "Rebuild needed due to router config changes."
+elif check_custom_feed_changes; then
+    REBUILD_NEEDED=true
+    echo "Rebuild needed due to custom feed changes."
+else
+    REBUILD_NEEDED=false
+    echo "No changes detected. Using existing build."
+fi
+
+# Use make if needed, else use image builder
 if [ "$REBUILD_NEEDED" = true ] || [ ! -f .firmware_built ] || [ .feeds_updated -nt .firmware_built ]; then
-    make -j$(nproc) V=sc > make_logs.md 2>&1
+    echo "Building OpenWrt..."
+    make -j$(nproc) V=sc > make_logs.md 2> >(tee -a make_logs.md >&2)
+
     touch .firmware_built
     
-    # Update last build info
-    echo "SCRIPT_COMMIT=$SCRIPT_COMMIT" > .last_build_info
-    echo "CUSTOM_FEED_COMMIT=$CUSTOM_FEED_COMMIT" >> .last_build_info
+    # Update the last build commit and build info
+    git -C "$SCRIPT_DIR" rev-parse HEAD > "$OPENWRT_DIR/.last_build_commit"
+    echo "SCRIPT_COMMIT=$SCRIPT_COMMIT" > "$OPENWRT_DIR/.last_build_info"
+    echo "CUSTOM_FEED_COMMIT=$CUSTOM_FEED_COMMIT" >> "$OPENWRT_DIR/.last_build_info"
+elif [ "$CONFIG_CHANGED" = true ]; then
+    echo "Configuration changed. Generating new sysupgrade.bin from existing binaries."
+    # Run install_script.sh to prepare custom files
+    $SCRIPT_DIR/install_script.sh "$SCRIPT_DIR" "$OPENWRT_DIR"
+
+    # Get target and subtarget based on router type
+    read TARGET SUBTARGET <<< $(get_target_subtarget "$ROUTER_TYPE")
+
+    if [ "$TARGET" = "unknown" ] || [ "$SUBTARGET" = "unknown" ]; then
+        echo "Error: Unknown router type $ROUTER_TYPE"
+        exit 1
+    fi
+
+    # Get the profile name from the config file
+    PROFILE=$(grep 'CONFIG_TARGET_PROFILE' $CONFIG_FILE | cut -d'"' -f2)
+
+    # Get the list of packages from the config file
+    PACKAGES=$(grep 'CONFIG_PACKAGE_' $CONFIG_FILE | grep '=y' | sed 's/CONFIG_PACKAGE_//g' | sed 's/=y//g' | tr '\n' ' ')
+
+    # Use build_images.sh to create the firmware
+    $SCRIPT_DIR/build_images.sh "${TARGET}/${SUBTARGET}" "$PROFILE" "$PACKAGES"
 else
-    echo "No rebuild needed. Using existing build."
+    echo "No changes detected. Using existing build."
 fi
 
 # Find and display the generated IPK files
@@ -124,7 +223,7 @@ TARGET_DIR="$OPENWRT_DIR/bin/packages"
 file_patterns=(
     "libwebsockets*.ipk"
     "libwally*.ipk"
-    "nodogsplash*.ipk"
+    "opennds*.ipk"
     "gltollgate*.ipk"
     "relaylink*.ipk"
     "signevent*.ipk"
@@ -164,12 +263,18 @@ if [ -z "$SYSUPGRADE_FILE" ]; then
     exit 1
 fi
 
-# Copy the file to the destination directory
-cp "$SYSUPGRADE_FILE" ~/TollGateNostrToolKit/binaries/.
+# Extract the base filename without extension
+BASE_FILENAME=$(basename "$SYSUPGRADE_FILE" .bin)
+
+# Create the new filename with commit hash
+NEW_FILENAME="${BASE_FILENAME}_${SCRIPT_COMMIT}.bin"
+
+# Copy the file to the destination directory with the new filename
+cp "$SYSUPGRADE_FILE" "$HOME/TollGateNostrToolKit/binaries/$NEW_FILENAME"
 
 # Check if copy was successful
 if [ $? -eq 0 ]; then
-    echo "Successfully copied $(basename "$SYSUPGRADE_FILE") to ~/TollGateNostrToolKit/binaries/."
+    echo "Successfully copied $NEW_FILENAME to ~/TollGateNostrToolKit/binaries/."
 else
     echo "Failed to copy file."
     exit 1

--- a/build_custom_dependencies.sh
+++ b/build_custom_dependencies.sh
@@ -223,7 +223,6 @@ TARGET_DIR="$OPENWRT_DIR/bin/packages"
 file_patterns=(
     "libwebsockets*.ipk"
     "libwally*.ipk"
-    "opennds*.ipk"
     "gltollgate*.ipk"
     "relaylink*.ipk"
     "signevent*.ipk"

--- a/build_images.sh
+++ b/build_images.sh
@@ -25,8 +25,6 @@ echo "Debug: Current working directory: $(pwd)"
 echo "Debug: Script location: $0"
 echo "Debug: HOME directory: $HOME"
 
-# Determine the Image Builder directory
-BUILDER_DIR="$HOME/openwrt/openwrt-imagebuilder-*-${TARGET_MAIN}-${SUBTARGET}.Linux-x86_64"
 
 # Add this function near the top of the script
 download_image_builder() {
@@ -58,25 +56,10 @@ download_image_builder() {
     mv "$builder_dir" "$HOME/openwrt/"
 }
 
-# Use globbing to find the directory
-BUILDER_DIR=$(echo $BUILDER_DIR)
 
-if [ ! -d "$BUILDER_DIR" ]; then
-    echo "Error: Image Builder not found at $BUILDER_DIR"
-    echo "Available Image Builders:"
-    find $HOME/openwrt -maxdepth 1 -type d -name "openwrt-imagebuilder-*" -print
-    echo "Debug: TARGET=$TARGET"
-    echo "Debug: TARGET_MAIN=$TARGET_MAIN"
-    echo "Debug: SUBTARGET=$SUBTARGET"
-    echo "Debug: BUILDER_DIR=$BUILDER_DIR"
-    exit 1
-fi
+BUILDER_DIR="$HOME/openwrt/openwrt-imagebuilder-*-${TARGET_MAIN}-${SUBTARGET}.Linux-x86_64"
 
 echo "Using Image Builder at: $BUILDER_DIR"
-
-# Replace the existing BUILDER_DIR assignment and check with this:
-BUILDER_DIR="$HOME/openwrt/openwrt-imagebuilder-*-${TARGET_MAIN}-${SUBTARGET}.Linux-x86_64"
-BUILDER_DIR=$(echo $BUILDER_DIR)
 
 # Check if Image Builder directory exists
 if [ ! -d "$BUILDER_DIR" ]; then

--- a/build_images.sh
+++ b/build_images.sh
@@ -13,12 +13,39 @@ if [ "$#" -ne 3 ]; then
 fi
 
 # Configuration
-OPENWRT_VERSION="23.05.4"
 TARGET="$1"
 PROFILE="$2"
 PACKAGES="$3"
-BUILDER_DIR="openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET/\//-}.Linux-x86_64"
-BINARIES_DIR="./binaries"
+
+# Split TARGET into TARGET and SUBTARGET
+TARGET_MAIN=$(echo $TARGET | cut -d'/' -f1)
+SUBTARGET=$(echo $TARGET | cut -d'/' -f2)
+
+echo "Debug: Current working directory: $(pwd)"
+echo "Debug: Script location: $0"
+echo "Debug: HOME directory: $HOME"
+
+# Determine the Image Builder directory
+BUILDER_DIR="$HOME/openwrt/openwrt-imagebuilder-*-${TARGET_MAIN}-${SUBTARGET}.Linux-x86_64"
+
+# Use globbing to find the directory
+BUILDER_DIR=$(echo $BUILDER_DIR)
+
+if [ ! -d "$BUILDER_DIR" ]; then
+    echo "Error: Image Builder not found at $BUILDER_DIR"
+    echo "Available Image Builders:"
+    find $HOME/openwrt -maxdepth 1 -type d -name "openwrt-imagebuilder-*" -print
+    echo "Debug: TARGET=$TARGET"
+    echo "Debug: TARGET_MAIN=$TARGET_MAIN"
+    echo "Debug: SUBTARGET=$SUBTARGET"
+    echo "Debug: BUILDER_DIR=$BUILDER_DIR"
+    exit 1
+fi
+
+echo "Using Image Builder at: $BUILDER_DIR"
+
+BINARIES_DIR="$HOME/TollGateNostrToolKit/binaries"
+OPENWRT_DIR="$HOME/openwrt"
 
 # Check if Image Builder directory exists
 if [ ! -d "$BUILDER_DIR" ]; then
@@ -33,18 +60,8 @@ mkdir -p "$BINARIES_DIR"
 # Change to the Image Builder directory
 cd "$BUILDER_DIR" || exit 1
 
-# Create a temporary file for UCI defaults
-UCI_DEFAULTS_FILE="files/etc/uci-defaults/99-custom-settings"
-mkdir -p "files/etc/uci-defaults"
-cat > "$UCI_DEFAULTS_FILE" << EOF
-#!/bin/sh
-
-$(cat ../uci_commands.sh)
-
-exit 0
-EOF
-
-chmod +x "$UCI_DEFAULTS_FILE"
+# Copy custom files from OpenWrt directory to Image Builder files directory
+cp -R "$OPENWRT_DIR/files/" "$BUILDER_DIR/files/"
 
 # Build the image
 echo "Building OpenWrt image..."
@@ -57,12 +74,14 @@ make image PROFILE="$PROFILE" PACKAGES="$PACKAGES" FILES="files"
 # Check if the build was successful
 if [ $? -eq 0 ]; then
     echo "Build successful!"
+    # Copy the generated sysupgrade.bin to the binaries directory
+    find bin/targets -name "*-sysupgrade.bin" -exec cp {} "$BINARIES_DIR" \;
 else
     echo "Build failed. Please check the output for errors."
 fi
 
 # Clean up
-rm -rf "files"
+# rm -rf "files"
 
 # Return to the original directory
 cd - > /dev/null

--- a/build_images.sh
+++ b/build_images.sh
@@ -28,10 +28,9 @@ echo "Debug: HOME directory: $HOME"
 
 # Add this function near the top of the script
 download_image_builder() {
-    local openwrt_version="23.05.4"
-    local builder_dir="openwrt-imagebuilder-${openwrt_version}-${TARGET_MAIN}-${SUBTARGET}.Linux-x86_64"
+    local builder_dir="openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET_MAIN}-${SUBTARGET}.Linux-x86_64"
     local builder_archive="${builder_dir}.tar.xz"
-    local download_url="https://downloads.openwrt.org/releases/${openwrt_version}/targets/${TARGET_MAIN}/${SUBTARGET}/${builder_archive}"
+    local download_url="https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET_MAIN}/${SUBTARGET}/${builder_archive}"
 
     echo "Downloading OpenWrt Image Builder for ${TARGET_MAIN}/${SUBTARGET}..."
     wget "$download_url"
@@ -52,12 +51,11 @@ download_image_builder() {
     echo "Cleaning up..."
     rm "$builder_archive"
 
-    BUILDER_DIR="$HOME/openwrt/$builder_dir"
     mv "$builder_dir" "$HOME/openwrt/"
 }
 
-
-BUILDER_DIR="$HOME/openwrt/openwrt-imagebuilder-*-${TARGET_MAIN}-${SUBTARGET}.Linux-x86_64"
+OPENWRT_VERSION="23.05.4"
+BUILDER_DIR="$HOME/openwrt/openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET_MAIN}-${SUBTARGET}.Linux-x86_64"
 
 echo "Using Image Builder at: $BUILDER_DIR"
 
@@ -65,6 +63,8 @@ echo "Using Image Builder at: $BUILDER_DIR"
 if [ ! -d "$BUILDER_DIR" ]; then
     echo "Image Builder not found. Attempting to download..."
     download_image_builder
+else
+    echo "Image Builder found at: $BUILDER_DIR"
 fi
 
 if [ ! -d "$BUILDER_DIR" ]; then

--- a/install_script.sh
+++ b/install_script.sh
@@ -44,9 +44,6 @@ if [ -d "$SCRIPT_DIR/files" ]; then
     chmod +x "$OPENWRT_DIR/files/etc/setup_vpn.sh"
     chmod +x "$OPENWRT_DIR/files/etc/startup_vpn.sh"
 
-    cp "$SCRIPT_DIR/files/uci-defaults/"* "$OPENWRT_DIR/files/etc/uci-defaults/"
-    chmod +x "$OPENWRT_DIR/files/etc/uci-defaults/"*
-
     cp "$SCRIPT_DIR/files/root/"* "$OPENWRT_DIR/files/root/"
     chmod +x "$OPENWRT_DIR/files/root/"*
 

--- a/install_script.sh
+++ b/install_script.sh
@@ -44,9 +44,6 @@ if [ -d "$SCRIPT_DIR/files" ]; then
     chmod +x "$OPENWRT_DIR/files/etc/setup_vpn.sh"
     chmod +x "$OPENWRT_DIR/files/etc/startup_vpn.sh"
 
-    cp "$SCRIPT_DIR/files/root/"* "$OPENWRT_DIR/files/root/"
-    chmod +x "$OPENWRT_DIR/files/root/"*
-
     cp "$SCRIPT_DIR/files/first-login-setup" "$OPENWRT_DIR/files/usr/local/bin/"
     cp "$SCRIPT_DIR/files/create_gateway.sh" "$OPENWRT_DIR/files/etc/"
     cp "$SCRIPT_DIR/files/activate_tollgate.sh" "$OPENWRT_DIR/files/etc/"

--- a/install_script.sh
+++ b/install_script.sh
@@ -58,9 +58,6 @@ if [ -d "$SCRIPT_DIR/files" ]; then
     mkdir -p "$OPENWRT_DIR/files/etc/opkg/"
     cp "$SCRIPT_DIR/files/distfeeds.conf" "$OPENWRT_DIR/files/etc/opkg/distfeeds.conf"
 
-    # Append the profile addon to /etc/profile
-    cat "$SCRIPT_DIR/files/profile.addon" >> "$OPENWRT_DIR/files/etc/profile"
-
     echo "Custom files copied to OpenWrt files directory"
 else
     echo "Custom files directory not found. Skipping manual installation."

--- a/install_script.sh
+++ b/install_script.sh
@@ -16,7 +16,6 @@ OPENWRT_DIR="$2"
 echo "SCRIPT_DIR: $SCRIPT_DIR"
 echo "OPENWRT_DIR: $OPENWRT_DIR"
 
-
 cd $OPENWRT_DIR
 
 # Manually install custom files
@@ -26,15 +25,18 @@ if [ -d "$SCRIPT_DIR/files" ]; then
     # Create necessary directories
     mkdir -p "$OPENWRT_DIR/files/www/cgi-bin"
     mkdir -p "$OPENWRT_DIR/files/usr/local/bin"
-    mkdir -p "$OPENWRT_DIR/files/etc/nodogsplash/htdocs"
     mkdir -p "$OPENWRT_DIR/files/etc/uci-defaults"
     mkdir -p "$OPENWRT_DIR/files/etc/config/"
     mkdir -p "$OPENWRT_DIR/files/etc/openvpn"
     mkdir -p "$OPENWRT_DIR/files/etc/init.d"
     mkdir -p "$OPENWRT_DIR/files/etc/rc.d"
     mkdir -p "$OPENWRT_DIR/files/etc"
+    mkdir -p "$OPENWRT_DIR/files/root"
 
-    cp "$SCRIPT_DIR/files/vpn/firewall" "$OPENWRT_DIR/files/etc/config/"
+    # Copy firewall and opennds config files to the correct location
+    cp "$SCRIPT_DIR/files/etc/config/firewall" "$OPENWRT_DIR/files/etc/config/"
+    cp "$SCRIPT_DIR/files/etc/config/opennds" "$OPENWRT_DIR/files/etc/config/"
+
     cp "$SCRIPT_DIR/files/vpn/network" "$OPENWRT_DIR/files/etc/config/"
     cp "$SCRIPT_DIR/files/vpn/openvpn" "$OPENWRT_DIR/files/etc/config/"
     cp "$SCRIPT_DIR/files/vpn/pia_latvia.ovpn" "$OPENWRT_DIR/files/etc/openvpn/"
@@ -46,18 +48,17 @@ if [ -d "$SCRIPT_DIR/files" ]; then
     chmod +x "$OPENWRT_DIR/files/etc/setup_vpn.sh"
     chmod +x "$OPENWRT_DIR/files/etc/startup_vpn.sh"
 
-    cp "$SCRIPT_DIR/files/80_mount_root" "$OPENWRT_DIR/files/etc/uci-defaults/"
+    cp "$SCRIPT_DIR/files/uci-defaults/"* "$OPENWRT_DIR/files/etc/uci-defaults/"
+    chmod +x "$OPENWRT_DIR/files/etc/uci-defaults/"*
+
+    cp "$SCRIPT_DIR/files/root/"* "$OPENWRT_DIR/files/root/"
+    chmod +x "$OPENWRT_DIR/files/root/"*
 
     cp "$SCRIPT_DIR/files/first-login-setup" "$OPENWRT_DIR/files/usr/local/bin/"
     cp "$SCRIPT_DIR/files/create_gateway.sh" "$OPENWRT_DIR/files/etc/"
     cp "$SCRIPT_DIR/files/activate_tollgate.sh" "$OPENWRT_DIR/files/etc/"
     cp "$SCRIPT_DIR/files/deactivate_tollgate.sh" "$OPENWRT_DIR/files/etc/"
     cp "$SCRIPT_DIR/files/cgi-bin/"*.sh "$OPENWRT_DIR/files/www/cgi-bin/"
-    cp -r "$SCRIPT_DIR/files/nodogsplash" "$OPENWRT_DIR/files/etc/config/" # Config files for openwrt (with UCI)
-    # rm -f "$OPENWRT_DIR/files/etc/nodogsplash/nodogsplash.conf" # Config files for traditional linux distros without UCI are required
-    cp -r "$SCRIPT_DIR/files/etc/nodogsplash/htdocs/"* "$OPENWRT_DIR/files/etc/nodogsplash/htdocs/"
-    cp -r "$SCRIPT_DIR/files/firewall.nodogsplash" "$OPENWRT_DIR/files/etc/"
-    cp -r "$SCRIPT_DIR/files/etc/nodogsplash" "$OPENWRT_DIR/files/etc/"
 
     # Set execute permissions
     chmod +x "$OPENWRT_DIR/files/usr/local/bin/first-login-setup"
@@ -66,19 +67,10 @@ if [ -d "$SCRIPT_DIR/files" ]; then
     # Copy uci_commands.sh and make it run on first boot
     mkdir -p "$OPENWRT_DIR/files/etc/opkg/"
     cp "$SCRIPT_DIR/files/distfeeds.conf" "$OPENWRT_DIR/files/etc/opkg/distfeeds.conf"
-    cp "$SCRIPT_DIR/files/uci_commands.sh" "$OPENWRT_DIR/files/etc/uci-defaults/99-custom-settings"
-    chmod +x "$OPENWRT_DIR/files/etc/uci-defaults/99-custom-settings"
 
-    # Directly modify /etc/profile
-    cat << 'EOF' >> "$OPENWRT_DIR/files/etc/profile"
+    # Append the profile addon to /etc/profile
+    cat "$SCRIPT_DIR/files/profile.addon" >> "$OPENWRT_DIR/files/etc/profile"
 
-# TollGateNostr first login setup
-if [ ! -f /etc/first_login_done ] && [ -t 0 ] && [ -t 1 ]; then
-    /usr/local/bin/first-login-setup
-fi
-EOF
-
-    chmod +x "$OPENWRT_DIR/files/etc/uci-defaults/80_mount_root"
     echo "Custom files copied to OpenWrt files directory"
 else
     echo "Custom files directory not found. Skipping manual installation."

--- a/install_script.sh
+++ b/install_script.sh
@@ -33,10 +33,6 @@ if [ -d "$SCRIPT_DIR/files" ]; then
     mkdir -p "$OPENWRT_DIR/files/etc"
     mkdir -p "$OPENWRT_DIR/files/root"
 
-    # Copy firewall and opennds config files to the correct location
-    cp "$SCRIPT_DIR/files/etc/config/firewall" "$OPENWRT_DIR/files/etc/config/"
-    cp "$SCRIPT_DIR/files/etc/config/opennds" "$OPENWRT_DIR/files/etc/config/"
-
     cp "$SCRIPT_DIR/files/vpn/network" "$OPENWRT_DIR/files/etc/config/"
     cp "$SCRIPT_DIR/files/vpn/openvpn" "$OPENWRT_DIR/files/etc/config/"
     cp "$SCRIPT_DIR/files/vpn/pia_latvia.ovpn" "$OPENWRT_DIR/files/etc/openvpn/"


### PR DESCRIPTION
Recycle existing binaries when nothing changed in the feeds or in the build .config file, so that the UCI scripts on the router can be modified without needing to rebuild everything - which takes long.